### PR TITLE
Small Interval refactors

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+rust stable

--- a/src/interval/interval_size.rs
+++ b/src/interval/interval_size.rs
@@ -49,8 +49,8 @@ impl fmt::Display for IntervalSize {
     }
 }
 
-impl From<i32> for IntervalSize {
-    fn from(value: i32) -> Self {
-        num::FromPrimitive::from_i32(value).map_or_else(|| todo!(), |size| size)
+impl From<u32> for IntervalSize {
+    fn from(value: u32) -> Self {
+        num::FromPrimitive::from_u32(value).map_or_else(|| todo!(), |size| size)
     }
 }

--- a/src/interval/tests.rs
+++ b/src/interval/tests.rs
@@ -21,7 +21,7 @@ fn new() {
     assert_eq!(interval.octaves, 1);
     assert_eq!(interval.polarity, Some(Positive));
 
-    let interval = Interval::new(Major, -2);
+    let interval = -Interval::new(Major, 2);
     assert_eq!(interval.interval_class.quality, Major);
     assert_eq!(interval.interval_class.size, Second);
     assert_eq!(interval.interval_class.polarity, Some(Negative));


### PR DESCRIPTION
* `Interval::new` only creates positive intervals, using `Neg` to negate them
  * Allows for simplifying some functions from having to check for negative
size values
* Reduce duplication in interval.quarter_sharp() and interval.quarter_flat()
