### PR TITLE
Additional functionality for leaf structs

### DIFF
--- a/src/chord/mod.rs
+++ b/src/chord/mod.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 
 use crate::duration::Duration;
+use crate::interval::Interval;
 use crate::leaf::Leaf;
 use crate::notehead::Notehead;
 use crate::pitch::Pitch;
@@ -33,12 +34,17 @@ impl Chord {
     }
 
     pub fn insert(&mut self, pitch: Pitch) {
-        let mut pitches = self.written_pitches();
-        pitches.insert(0, pitch);
-        pitches.sort();
-        self.noteheads = Self::pitches_to_notehead_list(&pitches);
+        self.noteheads.insert(0, Notehead::new(pitch));
+        self.noteheads.sort();
     }
 
+    pub fn transpose(&mut self, interval: Interval) {
+        self.noteheads
+            .iter_mut()
+            .for_each(|n| n.transpose(interval));
+    }
+
+    #[must_use]
     fn pitches_to_notehead_list(pitches: &[Pitch]) -> NoteheadList {
         pitches
             .iter()
@@ -47,7 +53,27 @@ impl Chord {
     }
 }
 
-impl Leaf for Chord {}
+impl Leaf for Chord {
+    fn written_duration(&self) -> Self::Duration {
+        self.written_duration
+    }
+
+    fn to_note(&self) -> Self::Note {
+        crate::note::Note::new(self.written_pitches()[0], self.written_duration)
+    }
+
+    fn to_rest(&self) -> Self::Rest {
+        crate::rest::Rest::new(self.written_duration)
+    }
+
+    fn to_spacer(&self) -> Self::Spacer {
+        crate::spacer::Spacer::new(self.written_duration)
+    }
+
+    fn to_chord(&self) -> Self::Chord {
+        self.clone()
+    }
+}
 
 impl ToLilypond for Chord {
     fn to_lilypond(&self) -> Result<String, crate::error::Error> {

--- a/src/chord/tests.rs
+++ b/src/chord/tests.rs
@@ -1,5 +1,7 @@
 use super::Chord;
 use crate::duration::Duration;
+use crate::interval::{Interval, Quality};
+use crate::leaf::Leaf;
 use crate::pitch::*;
 use crate::to_lilypond::ToLilypond;
 
@@ -18,6 +20,10 @@ fn c_major() -> Vec<Pitch> {
             4,
         ),
     ]
+}
+
+fn chord() -> Chord {
+    Chord::new(&c_major(), Duration::new(1, 4))
 }
 
 #[test]
@@ -79,4 +85,31 @@ fn to_lilypond() {
   g'
 >4"
     );
+}
+
+#[test]
+fn to_rest() {
+    assert_eq!(chord().to_rest().to_lilypond().unwrap(), "r4");
+}
+
+#[test]
+fn to_spacer() {
+    assert_eq!(chord().to_spacer().to_lilypond().unwrap(), "s4");
+}
+
+#[test]
+fn to_chord() {
+    assert_eq!(chord().to_chord(), chord());
+}
+
+#[test]
+fn to_note() {
+    assert_eq!(chord().to_note().to_lilypond().unwrap(), "c'4");
+}
+
+#[test]
+fn transpose() {
+    let mut chord = chord();
+    chord.transpose(Interval::new(Quality::Major, 3));
+    assert_eq!(chord.to_lilypond().unwrap(), "<\n  e'\n  gs'\n  b'\n>4");
 }

--- a/src/leaf.rs
+++ b/src/leaf.rs
@@ -1,3 +1,28 @@
+use crate::chord::Chord;
+use crate::duration::Duration;
+use crate::note::Note;
+use crate::rest::Rest;
+use crate::spacer::Spacer;
 use std::fmt::Debug;
 
-pub trait Leaf: Debug {}
+pub trait Leaf: Debug {
+    type Note = Note;
+    type Rest = Rest;
+    type Chord = Chord;
+    type Spacer = Spacer;
+    type Duration = Duration;
+
+    fn written_duration(&self) -> Self::Duration;
+
+    /// Converts the given `Leaf` to a `Note`
+    fn to_note(&self) -> Self::Note;
+
+    /// Converts the given `Leaf` to a `Rest`
+    fn to_rest(&self) -> Self::Rest;
+
+    /// Converts the given `Leaf` to a `Chord`
+    fn to_chord(&self) -> Self::Chord;
+
+    /// Converts the given `Leaf` to a `Spacer`
+    fn to_spacer(&self) -> Self::Spacer;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(const_option)]
 #![feature(const_result_drop)]
+#![feature(associated_type_defaults)]
 
 #[macro_use]
 extern crate num_derive;

--- a/src/notehead/accidental_display.rs
+++ b/src/notehead/accidental_display.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AccidentalDisplay {
     Cautionary,
     Forced,

--- a/src/notehead/mod.rs
+++ b/src/notehead/mod.rs
@@ -1,3 +1,4 @@
+use crate::interval::Interval;
 use crate::pitch::Pitch;
 use crate::to_lilypond::ToLilypond;
 
@@ -5,7 +6,7 @@ mod accidental_display;
 pub use accidental_display::AccidentalDisplay;
 
 #[must_use]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Notehead {
     written_pitch: Pitch,
     accidental_display: Option<AccidentalDisplay>,
@@ -17,6 +18,10 @@ impl Notehead {
             written_pitch,
             accidental_display: None,
         }
+    }
+
+    pub fn transpose(&mut self, interval: Interval) {
+        self.written_pitch = self.written_pitch().transpose(interval);
     }
 
     pub const fn forced(self) -> Self {
@@ -56,8 +61,11 @@ impl ToLilypond for Notehead {
 
 #[cfg(test)]
 mod tests {
-    use crate::pitch::*;
     use crate::to_lilypond::ToLilypond;
+    use crate::{
+        interval::{Interval, Quality},
+        pitch::*,
+    };
 
     use super::Notehead;
 
@@ -79,5 +87,19 @@ mod tests {
 
         let notehead3 = notehead2.neutral();
         assert_eq!(notehead3.to_lilypond().unwrap(), "c'");
+    }
+
+    #[test]
+    fn transpose() {
+        let pitch = Pitch::new(
+            PitchClass::new(DiatonicPitchClass::C, Accidental::Natural),
+            4,
+        );
+
+        let mut notehead = Notehead::new(pitch);
+
+        notehead.transpose(Interval::new(Quality::Perfect, 4));
+
+        assert_eq!(notehead.to_lilypond().unwrap(), "f'");
     }
 }

--- a/src/pitch/mod.rs
+++ b/src/pitch/mod.rs
@@ -116,5 +116,10 @@ impl fmt::Display for Pitch {
     }
 }
 
+pub const C4: Pitch = Pitch::new(
+    PitchClass::new(DiatonicPitchClass::C, Accidental::Natural),
+    4,
+);
+
 #[cfg(test)]
 mod tests;

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -14,7 +14,27 @@ impl Rest {
     }
 }
 
-impl Leaf for Rest {}
+impl Leaf for Rest {
+    fn written_duration(&self) -> Self::Duration {
+        self.written_duration
+    }
+
+    fn to_note(&self) -> Self::Note {
+        crate::note::Note::new(crate::pitch::C4, self.written_duration)
+    }
+
+    fn to_rest(&self) -> Self::Rest {
+        *self
+    }
+
+    fn to_chord(&self) -> Self::Chord {
+        crate::chord::Chord::new(&[crate::pitch::C4], self.written_duration)
+    }
+
+    fn to_spacer(&self) -> Self::Spacer {
+        crate::spacer::Spacer::new(self.written_duration)
+    }
+}
 
 impl ToLilypond for Rest {
     fn to_lilypond(&self) -> Result<String, crate::error::Error> {
@@ -30,10 +50,34 @@ mod tests {
     use super::*;
     use crate::duration::Duration;
 
+    fn rest() -> Rest {
+        Rest::new(Duration::new(3, 4))
+    }
+
     #[test]
     fn to_lilypond() {
         let rest = Rest::new(Duration::new(3, 4));
 
         assert_eq!(rest.to_lilypond().unwrap(), "r2.");
+    }
+
+    #[test]
+    fn to_rest() {
+        assert_eq!(rest().to_rest(), rest());
+    }
+
+    #[test]
+    fn to_spacer() {
+        assert_eq!(rest().to_spacer().to_lilypond().unwrap(), "s2.");
+    }
+
+    #[test]
+    fn to_chord() {
+        assert_eq!(rest().to_chord().to_lilypond().unwrap(), "<\n  c'\n>2.");
+    }
+
+    #[test]
+    fn to_note() {
+        assert_eq!(rest().to_note().to_lilypond().unwrap(), "c'2.");
     }
 }

--- a/src/spacer.rs
+++ b/src/spacer.rs
@@ -14,7 +14,27 @@ impl Spacer {
     }
 }
 
-impl Leaf for Spacer {}
+impl Leaf for Spacer {
+    fn written_duration(&self) -> Self::Duration {
+        self.written_duration
+    }
+
+    fn to_note(&self) -> Self::Note {
+        crate::note::Note::new(crate::pitch::C4, self.written_duration)
+    }
+
+    fn to_rest(&self) -> Self::Rest {
+        crate::rest::Rest::new(self.written_duration)
+    }
+
+    fn to_chord(&self) -> Self::Chord {
+        crate::chord::Chord::new(&[crate::pitch::C4], self.written_duration)
+    }
+
+    fn to_spacer(&self) -> Self::Spacer {
+        *self
+    }
+}
 
 impl ToLilypond for Spacer {
     fn to_lilypond(&self) -> Result<String, crate::error::Error> {
@@ -30,10 +50,34 @@ mod tests {
     use super::*;
     use crate::duration::Duration;
 
+    fn spacer() -> Spacer {
+        Spacer::new(Duration::new(7, 16))
+    }
+
     #[test]
     fn to_lilypond() {
         let spacer = Spacer::new(Duration::new(7, 16));
 
         assert_eq!(spacer.to_lilypond().unwrap(), "s4..");
+    }
+
+    #[test]
+    fn to_rest() {
+        assert_eq!(spacer().to_rest().to_lilypond().unwrap(), "r4..");
+    }
+
+    #[test]
+    fn to_spacer() {
+        assert_eq!(spacer().to_spacer(), spacer());
+    }
+
+    #[test]
+    fn to_chord() {
+        assert_eq!(spacer().to_chord().to_lilypond().unwrap(), "<\n  c'\n>4..");
+    }
+
+    #[test]
+    fn to_note() {
+        assert_eq!(spacer().to_note().to_lilypond().unwrap(), "c'4..");
     }
 }


### PR DESCRIPTION
* Simplify inserting pitch into chord
* Implement functions converting between leaf types
* Add `transpose` for Notehead, Note, and Chord
