### PR TITLE
Moves Duration.is_printable() check to leaf initializers, not `to_lilypond`

### DIFF
--- a/src/chord/tests.rs
+++ b/src/chord/tests.rs
@@ -23,28 +23,27 @@ fn c_major() -> Vec<Pitch> {
 }
 
 fn chord() -> Chord {
-    Chord::new(&c_major(), Duration::new(1, 4))
+    Chord::new(&c_major(), Duration::new(1, 4)).unwrap()
 }
 
 #[test]
 fn written_pitches() {
     let pitches = c_major();
-    let chord = Chord::new(&pitches, Duration::new(1, 4));
 
-    assert_eq!(chord.written_pitches(), pitches);
+    assert_eq!(chord().written_pitches(), pitches);
 }
 
 #[test]
 fn insert_pitch() {
-    let mut chord = Chord::new(&c_major(), Duration::new(1, 4));
+    let mut ch = chord();
 
-    chord.insert(Pitch::new(
+    ch.insert(Pitch::new(
         PitchClass::new(DiatonicPitchClass::B, Accidental::Flat),
         3,
     ));
 
     assert_eq!(
-        chord.to_lilypond().unwrap(),
+        ch.to_lilypond().unwrap(),
         "<
   bf
   c'
@@ -53,15 +52,15 @@ fn insert_pitch() {
 >4"
     );
 
-    let mut chord = Chord::new(&c_major(), Duration::new(1, 4));
+    let mut ch = chord();
 
-    chord.insert(Pitch::new(
+    ch.insert(Pitch::new(
         PitchClass::new(DiatonicPitchClass::B, Accidental::Flat),
         4,
     ));
 
     assert_eq!(
-        chord.to_lilypond().unwrap(),
+        ch.to_lilypond().unwrap(),
         "<
   c'
   e'
@@ -73,12 +72,8 @@ fn insert_pitch() {
 
 #[test]
 fn to_lilypond() {
-    let pitches = c_major();
-
-    let chord = Chord::new(&pitches, Duration::new(1, 4));
-
     assert_eq!(
-        chord.to_lilypond().unwrap(),
+        chord().to_lilypond().unwrap(),
         "<
   c'
   e'

--- a/src/duration/lilypond.rs
+++ b/src/duration/lilypond.rs
@@ -36,7 +36,7 @@ impl ToLilypond for Duration {
         if self.is_printable() {
             Ok(format!("{}{}", base_duration_string(*self), dots(*self)))
         } else {
-            Err(Error::UnprintableDuration(self.numerator, self.denominator))
+            Err(Error::UnprintableDuration(*self))
         }
     }
 }

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -18,6 +18,16 @@ impl Duration {
     }
 
     #[must_use]
+    pub const fn numerator(self) -> i32 {
+        self.numerator
+    }
+
+    #[must_use]
+    pub const fn denominator(self) -> i32 {
+        self.denominator
+    }
+
+    #[must_use]
     pub const fn as_tuple(self) -> (i32, i32) {
         (self.numerator, self.denominator)
     }

--- a/src/duration/tests.rs
+++ b/src/duration/tests.rs
@@ -262,13 +262,13 @@ fn to_lilypond() {
 #[test]
 fn to_lilypond_for_unprintable_durations() {
     let mut d = Duration::new(23, 1);
-    assert_eq!(d.to_lilypond(), Err(Error::UnprintableDuration(23, 1)));
+    assert_eq!(d.to_lilypond(), Err(Error::UnprintableDuration(d)));
 
     d = Duration::new(5, 8);
-    assert_eq!(d.to_lilypond(), Err(Error::UnprintableDuration(5, 8)));
+    assert_eq!(d.to_lilypond(), Err(Error::UnprintableDuration(d)));
 
     d = Duration::new(1, 5);
-    assert_eq!(d.to_lilypond(), Err(Error::UnprintableDuration(1, 5)));
+    assert_eq!(d.to_lilypond(), Err(Error::UnprintableDuration(d)));
 }
 
 #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,15 @@
+use crate::duration::Duration;
 use crate::interval::{IntervalSize, Quality};
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum Error {
-    #[error("cannot print duration {0}/{1}")]
-    UnprintableDuration(i32, i32),
+    #[error("cannot print duration {}/{}", .0.numerator(), .0.denominator())]
+    UnprintableDuration(Duration),
     #[error("cannot create interval class {0} {1}")]
     InvalidIntervalClass(Quality, IntervalSize),
     #[error("cannot create accidental from {0}")]
     InvalidAccidentalSize(f32),
+    #[error("unhandled generic error")]
+    GenericError,
 }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,4 +1,5 @@
 use crate::duration::Duration;
+use crate::error::Error;
 use crate::leaf::Leaf;
 use crate::to_lilypond::ToLilypond;
 
@@ -9,8 +10,18 @@ pub struct Rest {
 }
 
 impl Rest {
-    pub const fn new(written_duration: Duration) -> Self {
-        Self { written_duration }
+    /// Returns a new `Spacer` from the given `Duration`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `UnprintableDuration` error if the given `Duration` cannot be rendered by a
+    /// single notehead in a score.
+    pub fn new(written_duration: Duration) -> Result<Self, Error> {
+        if written_duration.is_printable() {
+            Ok(Self { written_duration })
+        } else {
+            Err(Error::UnprintableDuration(written_duration))
+        }
     }
 }
 
@@ -20,7 +31,7 @@ impl Leaf for Rest {
     }
 
     fn to_note(&self) -> Self::Note {
-        crate::note::Note::new(crate::pitch::C4, self.written_duration)
+        crate::note::Note::new(crate::pitch::C4, self.written_duration).unwrap()
     }
 
     fn to_rest(&self) -> Self::Rest {
@@ -28,11 +39,11 @@ impl Leaf for Rest {
     }
 
     fn to_chord(&self) -> Self::Chord {
-        crate::chord::Chord::new(&[crate::pitch::C4], self.written_duration)
+        crate::chord::Chord::new(&[crate::pitch::C4], self.written_duration).unwrap()
     }
 
     fn to_spacer(&self) -> Self::Spacer {
-        crate::spacer::Spacer::new(self.written_duration)
+        crate::spacer::Spacer::new(self.written_duration).unwrap()
     }
 }
 
@@ -51,14 +62,12 @@ mod tests {
     use crate::duration::Duration;
 
     fn rest() -> Rest {
-        Rest::new(Duration::new(3, 4))
+        Rest::new(Duration::new(3, 4)).unwrap()
     }
 
     #[test]
     fn to_lilypond() {
-        let rest = Rest::new(Duration::new(3, 4));
-
-        assert_eq!(rest.to_lilypond().unwrap(), "r2.");
+        assert_eq!(rest().to_lilypond().unwrap(), "r2.");
     }
 
     #[test]


### PR DESCRIPTION
Addresses #9
